### PR TITLE
feat: improve sign-up form with error handling for unexpected failures and redirect to sign-in page

### DIFF
--- a/components/organisms/auth-forms/sign-in-form.tsx
+++ b/components/organisms/auth-forms/sign-in-form.tsx
@@ -42,7 +42,6 @@ function SignInForm() {
             toast.error("Please fill in all fields.");
             return;
         }
-
         const response = await signInAction(d);
 
         if (!response.success) {

--- a/components/organisms/auth-forms/sign-up-form.tsx
+++ b/components/organisms/auth-forms/sign-up-form.tsx
@@ -18,8 +18,10 @@ import { SignUpSchema, type SignUpSchemaType } from "@/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signUpAction } from "@/actions";
 import { toast } from "sonner";
+import { useRouter } from "next/router";
 
 function SignUpForm() {
+    const router = useRouter();
     const signUpForm = useForm({
         defaultValues: {
             email: "",
@@ -52,7 +54,13 @@ function SignUpForm() {
         }
 
         const userData = response.data;
+        if (!userData) {
+            toast.error("Unexpected signup failure.");
+            return;
+        }
+
         toast.success("Registration successful!");
+        router.push("/signin"); // Redirect to sign-in page after successful registration
     };
     return (
         <Form {...signUpForm}>


### PR DESCRIPTION
This pull request introduces improvements to the user authentication forms by enhancing error handling and adding a redirection feature after successful registration. The changes primarily focus on the `SignUpForm` and `SignInForm` components.

### Enhancements to `SignUpForm`:

* Added a check for `userData` after the signup action to handle unexpected failures, displaying an error message if no data is returned.
* Introduced a redirection to the sign-in page after successful registration by utilizing the `useRouter` hook from Next.js. [[1]](diffhunk://#diff-580605631f74a38165f322645dae07f54f65191e640bbf369571be6da0cbd8d6R21-R24) [[2]](diffhunk://#diff-580605631f74a38165f322645dae07f54f65191e640bbf369571be6da0cbd8d6R57-R63)

### Minor change to `SignInForm`:

* Removed an unnecessary blank line to clean up the code.