### PR TITLE
feat: add blog actions for create, read, update, and delete functionalities

### DIFF
--- a/actions/blogs.ts
+++ b/actions/blogs.ts
@@ -1,0 +1,84 @@
+"use server";
+
+import { NewBlogSchema, type NewBlogSchemaType } from "@/schemas";
+import { supabaseServerClient } from "@/utils/supabase/supabase";
+import { revalidatePath } from "next/cache";
+
+const createBlogAction = async (values: NewBlogSchemaType) => {
+    try {
+        const validatedData = NewBlogSchema.safeParse(values);
+        if (!validatedData.success) return { success: false, message: "Invalid input data." };
+
+        const {
+            data: { title, content },
+        } = validatedData;
+        if (title === "" || content === "") return { success: false, message: "Title and content cannot be empty." };
+
+        const supabase = await supabaseServerClient();
+        const { data, error } = await supabase.from("blogs").insert([{ title, content }]).select();
+
+        if (error) return { success: false, message: error.message };
+        else if (!data || data.length === 0) return { success: false, message: "Unexpected blog creation failure." };
+        revalidatePath("/home");
+        return { success: true, data };
+    } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        return { success: false, message: errorMessage };
+    }
+};
+
+const getBlogsAction = async () => {
+    try {
+        const supabase = await supabaseServerClient();
+        console.log(supabase.auth.getSession());
+        const { data, error } = await supabase.from("blogs").select("*").order("created_at", { ascending: false });
+
+        console.log();
+        if (error) return { success: false, message: error.message };
+        else if (!data || data.length === 0) return { success: false, message: "No blogs found." };
+        return { success: true, data };
+    } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        return { success: false, message: errorMessage };
+    }
+};
+
+const updateBlogAction = async (blog_id: string, values: NewBlogSchemaType) => {
+    try {
+        const validatedData = NewBlogSchema.safeParse(values);
+        if (!validatedData.success) return { success: false, message: "Invalid input data." };
+
+        const {
+            data: { title, content },
+        } = validatedData;
+        if (title === "" || content === "") return { success: false, message: "Title and content cannot be empty." };
+
+        const supabase = await supabaseServerClient();
+        const { data, error } = await supabase.from("blogs").update({ title, content }).eq("blog_id", blog_id).select();
+
+        if (error) return { success: false, message: error.message };
+        else if (!data || data.length === 0) return { success: false, message: "Unexpected blog update failure." };
+        revalidatePath("/home");
+        return { success: true, data };
+    } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        return { success: false, message: errorMessage };
+    }
+};
+
+const deleteBlogAction = async (blog_id: string) => {
+    try {
+        const supabase = await supabaseServerClient();
+        const { data, error } = await supabase.from("blogs").delete().eq("blog_id", blog_id).select();
+
+        if (error) return { success: false, message: error.message };
+        else if (!data || data.length === 0) return { success: false, message: "Unexpected blog deletion failure." };
+        revalidatePath("/home");
+        return { success: true, data };
+    } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        return { success: false, message: errorMessage };
+    }
+};
+
+export { createBlogAction, getBlogsAction, updateBlogAction, deleteBlogAction };

--- a/actions/index.ts
+++ b/actions/index.ts
@@ -1,1 +1,2 @@
 export { signInAction, signUpAction } from "./auth";
+export { getBlogsAction, createBlogAction, deleteBlogAction, updateBlogAction } from "./blogs";


### PR DESCRIPTION
This pull request introduces CRUD (Create, Read, Update, Delete) actions for managing blog entries using Supabase and integrates these actions into the application. The changes include the implementation of the actions in a new file and their export in the main `actions` index file.

### Blog management actions:

* `actions/blogs.ts`: Added four new asynchronous functions:
  - `createBlogAction` to validate input and create a new blog entry in the Supabase database.
  - `getBlogsAction` to fetch and return all blog entries, sorted by creation date.
  - `updateBlogAction` to validate input and update an existing blog entry by `blog_id`.
  - `deleteBlogAction` to delete a blog entry by `blog_id`.

### Integration:

* [`actions/index.ts`](diffhunk://#diff-9f5cd4e90e77780854f17cf7de394577f766b852bd45ef1b8ef78f8ad213f3d9R2): Exported the newly added blog actions (`getBlogsAction`, `createBlogAction`, `deleteBlogAction`, `updateBlogAction`) for use throughout the application.